### PR TITLE
fix: multiple husky print & prettier path

### DIFF
--- a/.husky/pre-commit
+++ b/.husky/pre-commit
@@ -1,4 +1,8 @@
 #!/usr/bin/env sh
 . "$(dirname -- "$0")/_/husky.sh"
 
+if [ -t 2 ]; then
+  exec >/dev/tty 2>&1
+fi
+
 yarn lint-staged

--- a/.lintstagedrc.js
+++ b/.lintstagedrc.js
@@ -2,9 +2,10 @@ module.exports = {
   // Lint & Prettify JSX and JS files
   "**/*.(jsx|js)": (filenames) => [
     `yarn lint`,
-    `yarn prettier --write ${filenames.join(" ")}`,
+    `yarn prettier --write "${filenames.join('" "')}"`,
   ],
 
   // Prettify only JSON files
-  "**/*.(json)": (filenames) => `yarn prettier --write ${filenames.join(" ")}`,
+  "**/*.(json)": (filenames) =>
+    `yarn prettier --write "${filenames.join('" "')}"`,
 };


### PR DESCRIPTION
This is only fix issue for windows environment.

- For husky is print multipe task. Ref: https://github.com/typicode/husky/issues/968#issuecomment-1176848345
- For prettier is need to wrap with `"..."` if the path contain a space.