### PR TITLE
feat: code readability for pluralizing 'challenge'

### DIFF
--- a/app/page.jsx
+++ b/app/page.jsx
@@ -26,7 +26,8 @@ export default function Home() {
         <p className="text-brand text-2xl leading-relaxed">Difficulty</p>
         <DropdownDifficulties onChange={setDifficultyFilter} />
         <p className="text-brand text-2xl leading-relaxed">
-          /{challenges.length} challanges
+          /{challenges.length}{' '}
+          {challenges.length > 1 ? 'challenges' : 'challenge'}
         </p>
       </div>
       {challenges.map(


### PR DESCRIPTION
## Pluralizing text
Improve code readability for pluralizing **challenge** or **challenges** in the home page.

### Before
![image](https://user-images.githubusercontent.com/36098718/219869083-ec910d03-332c-4173-b1f9-696e683fcd3b.png)
![image](https://user-images.githubusercontent.com/36098718/219869122-b7340fc7-f830-4648-ad73-c6370e08b95b.png)
And there is also a typo **challanges**.

### After
![image](https://user-images.githubusercontent.com/36098718/219869186-335f5c75-399d-407c-8676-ded93ce91606.png)
![image](https://user-images.githubusercontent.com/36098718/219869165-5734a278-ac8b-4ef7-94ba-f84857d991b9.png)