### PR TITLE
`ScrollToTop` not showing on mobile screen

### DIFF
--- a/app/page.tsx
+++ b/app/page.tsx
@@ -75,7 +75,7 @@ export default function Home() {
               image={image}
               name={name}
               slug={slug}
-              shortDescription={description.substring(0, 100)}
+              shortDescription={description.substring(0, MAX_DESC_LENGTH)}
               difficulty={difficulty}
               category={category}
               accent={accent}

--- a/components/ScrollToTop.tsx
+++ b/components/ScrollToTop.tsx
@@ -1,5 +1,6 @@
 'use client';
 
+import clsx from 'clsx';
 import { Arrow } from 'doodle-icons';
 import { useEffect, useState } from 'react';
 
@@ -30,10 +31,13 @@ export default function ScrollToTop() {
 
   return (
     <button
-      className={`fixed bottom-10 right-10 bg-brand p-1.5 hover:-translate-y-1 transition-transform w-10 h-10 ${
+      className={clsx(
+        'fixed bottom-28 lg:bottom-10 right-10',
+        'bg-brand border-2 border-black py-3 px-2',
+        'hover:-translate-y-1 transition-transform',
         isVisible ? 'block' : 'hidden'
-      }`}
-      style={{ boxShadow: '5px 5px 0 #000' }}
+      )}
+      style={{ boxShadow: '4px 4px 0 #000' }}
       onClick={scrollToTop}
     >
       <Arrow.ArrowSingleUp width="30" aria-hidden="true" />


### PR DESCRIPTION
I fixed `ScrollToTop` component position that covered by `nav` on mobile screen.
Also I added a border and reduce the shadow size.

### Before
![image](https://user-images.githubusercontent.com/36098718/225494653-e97c091a-ea6f-45f2-ba27-6a8b4478629a.png)

### After
![image](https://user-images.githubusercontent.com/36098718/225494726-0d12e1fa-ba24-44e1-bef4-639cb1727389.png)
