### PR TITLE
style: add underline on 'Read License' link in challenge page

### DIFF
--- a/app/challenge/[slug]/page.tsx
+++ b/app/challenge/[slug]/page.tsx
@@ -111,6 +111,7 @@ async function Page({ params: { slug } }: Params) {
                 href="https://creativecommons.org/licenses/by/4.0/"
                 target="_blank"
                 rel="noreferrer"
+                className='underline font-medium'
               >
                 Read The License
               </a>


### PR DESCRIPTION
Adding an underline on the 'Read License' link on the challenge page to make it clear that it's a link.

PR for this issue : https://github.com/nauvalazhar/code-design/issues/86#issue-2297291062